### PR TITLE
documentation typo

### DIFF
--- a/hist/hist/src/TFitResultPtr.cxx
+++ b/hist/hist/src/TFitResultPtr.cxx
@@ -16,7 +16,7 @@
 /** \class TFitResultPtr
 Provides an indirection to the TFitResult class and with a semantics
 identical to a TFitResult pointer, i.e. it is like a smart pointer to a TFitResult.
-In addition it provides an automatic comversion to an integer. In this way it can be
+In addition it provides an automatic conversion to an integer. In this way it can be
 returned from the TH1::Fit method and the change in TH1::Fit be backward compatible.
  */
 


### PR DESCRIPTION
# This Pull request:
Fix for a trivial documentation typo.

## Changes or fixes:
This fixes a typo in the documentation of `TFitResultPtr` class.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

